### PR TITLE
fix: get OPENAI_API_PROXY_ADDR environment variable error

### DIFF
--- a/connectors/openai-api/openai.go
+++ b/connectors/openai-api/openai.go
@@ -13,7 +13,7 @@ import (
 func GetClient() *openai.Client {
 	config := openai.DefaultConfig(define.OPENAI_API_KEY)
 	if define.ENABLE_OPENAI_API_PROXY {
-		proxyUrl, err := url.Parse(define.DEFAULT_OPENAI_API_PROXY_ADDR)
+		proxyUrl, err := url.Parse(define.OPENAI_API_PROXY_ADDR)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
![image](https://github.com/soulteary/sparrow/assets/13060680/deb83bcc-ab57-4e64-9def-ae055e807f28)

书写错误，应为 `OPENAI_API_PROXY_ADDR`